### PR TITLE
Improve Anime Panel window.

### DIFF
--- a/queries/MediaList.gql
+++ b/queries/MediaList.gql
@@ -13,6 +13,14 @@ query ($userId: Int) {
         hiddenFromStatusLists
         customLists
         media {
+          studios {
+            edges {
+              isMain
+              node {
+                name
+              }            
+            }
+          }
           id
           title {
             english

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,11 +96,14 @@ int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
   a.setStyleSheet(style);
 
-  //QFile logFile(Paths::logFileName());
-  //if (logFile.exists()) logFile.remove();
+#ifdef QT_NO_DEBUG
+  QFile logFile(Paths::logFileName());
+  if (logFile.exists()) logFile.remove();
 
-  //qInstallMessageHandler(File);
+  qInstallMessageHandler(File);
+#else
   qInstallMessageHandler(Cerr);
+#endif
 
 #ifndef QT_DEBUG
   Breakpad::CrashHandler::instance()->Init(qApp->applicationDirPath());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,14 +96,11 @@ int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
   a.setStyleSheet(style);
 
-#ifdef QT_NO_DEBUG
-  QFile logFile(Paths::logFileName());
-  if (logFile.exists()) logFile.remove();
+  //QFile logFile(Paths::logFileName());
+  //if (logFile.exists()) logFile.remove();
 
-  qInstallMessageHandler(File);
-#else
+  //qInstallMessageHandler(File);
   qInstallMessageHandler(Cerr);
-#endif
 
 #ifndef QT_DEBUG
   Breakpad::CrashHandler::instance()->Init(qApp->applicationDirPath());

--- a/src/models/media.cpp
+++ b/src/models/media.cpp
@@ -112,6 +112,14 @@ void Media::setTags(const QStringList &tags) {
   m_tags = tags;
 }
 
+QStringList Media::studios() const {
+  return m_studios;
+}
+
+void Media::setStudios(const QStringList &studios) {
+  m_studios = studios;
+}
+
 bool Media::hasNextAiringEpisode() const {
   return m_hasNextAiringEpisode;
 }
@@ -333,4 +341,21 @@ void Media::loadInnerMedia(const QJsonObject &innerMedia) {
       this->setSequel(id);
     }
   }
+
+  QStringList studios;
+  auto studiosObject = innerMedia.value("studios").toObject();
+  edgesArray = studiosObject.value("edges").toArray();
+
+  for (auto &&edge : edgesArray) {
+      auto edgeObject = edge.toObject();
+
+      if (!edgeObject.value("isMain").toBool()) {
+          continue;
+      }
+
+      auto studio = edgeObject.value("node").toObject();
+      studios.append(studio.value("name").toString());
+  }
+
+  this->setStudios(studios);
 }

--- a/src/models/media.h
+++ b/src/models/media.h
@@ -53,6 +53,9 @@ class Media : public QObject {
   QStringList tags() const;
   void setTags(const QStringList &tags);
 
+  QStringList studios() const;
+  void setStudios(const QStringList &studios);
+
   bool hasNextAiringEpisode() const;
   void setHasNextAiringEpisode(bool hasNextAiringEpisode);
 
@@ -113,6 +116,7 @@ class Media : public QObject {
   QStringList m_synonyms{};
   QStringList m_genres{};
   QStringList m_tags{};
+  QStringList m_studios{};
   bool m_hasNextAiringEpisode{false};
   QDateTime m_airingAt{};
   int m_nextAiringEpisode{0};

--- a/ui/anime_panel.cpp
+++ b/ui/anime_panel.cpp
@@ -30,7 +30,7 @@ AnimePanel::AnimePanel(Media *media, QWidget *parent)
   ui->status->setText(tr(qPrintable(media->airingStatus())));
   ui->genres->setText(combinedGenreTags.join(", "));
   ui->studios->setText(media->studios().join(", "));
-  ui->air_date->setText(media->airingAt().toString("ddd MMMM d yyyy"));
+  ui->air_date->setText(media->airingAt().toString(Qt::TextDate));
 
   FileDownloader *f = new FileDownloader(media->coverImage());
 

--- a/ui/anime_panel.cpp
+++ b/ui/anime_panel.cpp
@@ -13,6 +13,7 @@ AnimePanel::AnimePanel(Media *media, QWidget *parent)
     : QDialog(parent), ui(new Ui::AnimePanel), media(media) {
   ui->setupUi(this);
   ui->tabWidget->setCurrentIndex(0);
+  this->setWindowTitle(qApp->applicationName() + " - " + media->title());
 
   QStringList combinedGenreTags = media->genres();
 

--- a/ui/anime_panel.cpp
+++ b/ui/anime_panel.cpp
@@ -28,6 +28,8 @@ AnimePanel::AnimePanel(Media *media, QWidget *parent)
   ui->episodes->setText(QString::number(media->episodes()));
   ui->status->setText(tr(qPrintable(media->airingStatus())));
   ui->genres->setText(combinedGenreTags.join(", "));
+  ui->studios->setText(media->studios().join(", "));
+  ui->air_date->setText(media->airingAt().toString("ddd MMMM d yyyy"));
 
   FileDownloader *f = new FileDownloader(media->coverImage());
 

--- a/ui/anime_panel.ui
+++ b/ui/anime_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>400</height>
+    <height>459</height>
    </rect>
   </property>
   <property name="modal">
@@ -42,6 +42,86 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Synonyms</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>5</number>
+        </property>
+        <property name="bottomMargin">
+         <number>5</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="synonyms">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Genres &amp;&amp; Tags</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_8">
+        <property name="leftMargin">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>5</number>
+        </property>
+        <property name="bottomMargin">
+         <number>5</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="genres">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -50,6 +130,22 @@
         <size>
          <width>20</width>
          <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
         </size>
        </property>
       </spacer>
@@ -75,7 +171,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="tab">
         <attribute name="title">
@@ -83,7 +179,7 @@
         </attribute>
         <layout class="QVBoxLayout" name="verticalLayout_7">
          <item>
-          <widget class="QGroupBox" name="groupBox">
+          <widget class="QGroupBox" name="groupBox_3">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -91,9 +187,9 @@
             </font>
            </property>
            <property name="title">
-            <string>Synonyms</string>
+            <string>Description</string>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_4">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <property name="leftMargin">
              <number>5</number>
             </property>
@@ -107,16 +203,59 @@
              <number>5</number>
             </property>
             <item>
-             <widget class="QLabel" name="synonyms">
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="wordWrap">
+             <widget class="QScrollArea" name="scrollArea">
+              <property name="widgetResizable">
                <bool>true</bool>
               </property>
+              <widget class="QWidget" name="scrollAreaWidgetContents">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>361</width>
+                 <height>167</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_9">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>2</number>
+                </property>
+                <property name="topMargin">
+                 <number>2</number>
+                </property>
+                <property name="rightMargin">
+                 <number>2</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>2</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="description">
+                  <property name="font">
+                   <font>
+                    <weight>50</weight>
+                    <bold>false</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="textFormat">
+                   <enum>Qt::RichText</enum>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
              </widget>
             </item>
            </layout>
@@ -189,6 +328,20 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>Studios:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Air date:</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
             <item>
@@ -213,130 +366,21 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QLabel" name="studios">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="air_date">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
              </layout>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="groupBox_4">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>Genres &amp;&amp; Tags</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <property name="leftMargin">
-             <number>5</number>
-            </property>
-            <property name="topMargin">
-             <number>5</number>
-            </property>
-            <property name="rightMargin">
-             <number>5</number>
-            </property>
-            <property name="bottomMargin">
-             <number>5</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="genres">
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="groupBox_3">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>Description</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="leftMargin">
-             <number>5</number>
-            </property>
-            <property name="topMargin">
-             <number>5</number>
-            </property>
-            <property name="rightMargin">
-             <number>5</number>
-            </property>
-            <property name="bottomMargin">
-             <number>5</number>
-            </property>
-            <item>
-             <widget class="QScrollArea" name="scrollArea">
-              <property name="widgetResizable">
-               <bool>true</bool>
-              </property>
-              <widget class="QWidget" name="scrollAreaWidgetContents">
-               <property name="geometry">
-                <rect>
-                 <x>0</x>
-                 <y>0</y>
-                 <width>361</width>
-                 <height>71</height>
-                </rect>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_9">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="leftMargin">
-                 <number>2</number>
-                </property>
-                <property name="topMargin">
-                 <number>2</number>
-                </property>
-                <property name="rightMargin">
-                 <number>2</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>2</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="description">
-                  <property name="font">
-                   <font>
-                    <weight>50</weight>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="textFormat">
-                   <enum>Qt::RichText</enum>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </widget>
             </item>
            </layout>
           </widget>
@@ -441,19 +485,6 @@
                </spacer>
               </item>
              </layout>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Progress:</string>
-              </property>
-             </widget>
             </item>
             <item row="1" column="1">
              <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -662,6 +693,19 @@
                </spacer>
               </item>
              </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Progress:</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>

--- a/ui/main_window/components/rss_table_model.cpp
+++ b/ui/main_window/components/rss_table_model.cpp
@@ -4,6 +4,7 @@ RSSTableModel::RSSTableModel(QObject *parent) : QAbstractTableModel(parent) {}
 
 void RSSTableModel::setList(const QList<RSSItem *> &list) {
   m_list = list;
+  refresh();
 }
 
 void RSSTableModel::refresh() {

--- a/ui/main_window/components/rss_table_model.cpp
+++ b/ui/main_window/components/rss_table_model.cpp
@@ -31,12 +31,16 @@ QVariant RSSTableModel::headerData(int s, Qt::Orientation o, int r) const {
   return QVariant();
 }
 
+RSSItem* RSSTableModel::item(const QModelIndex &index) const {
+    return *(m_list.begin() + index.row());
+}
+
 QVariant RSSTableModel::data(const QModelIndex &index, int role) const {
   if (index.row() < 0 || index.row() >= m_list.count() || role != Qt::DisplayRole) {
     return QVariant();
   }
 
-  RSSItem *item = *(m_list.begin() + index.row());
+  RSSItem *item = this->item(index);
 
   switch (index.column()) {
     case RSSRoles::Title:

--- a/ui/main_window/components/rss_table_model.h
+++ b/ui/main_window/components/rss_table_model.h
@@ -34,6 +34,7 @@ class RSSTableModel : public QAbstractTableModel {
   QVariant headerData(int section, Qt::Orientation orientation, int role) const;
   int rowCount(const QModelIndex &parent = QModelIndex()) const;
   int columnCount(const QModelIndex &parent = QModelIndex()) const;
+  RSSItem* item(const QModelIndex &index) const;
   QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 
  private:

--- a/ui/main_window/views/torrents.cpp
+++ b/ui/main_window/views/torrents.cpp
@@ -30,8 +30,7 @@ Torrents::Torrents(QWidget *parent)
   ui->torrentTable->setSelectionMode(QAbstractItemView::SingleSelection);
 
   connect(ui->refreshButton, &QPushButton::clicked, this, [this]() {
-    refresh = 1;
-    timerTick();
+    fetchTorrents();
   });
 
   connect(timer, SIGNAL(timeout()), this, SLOT(timerTick()));

--- a/ui/main_window/views/torrents.cpp
+++ b/ui/main_window/views/torrents.cpp
@@ -30,7 +30,11 @@ Torrents::Torrents(QWidget *parent)
   ui->torrentTable->setSelectionMode(QAbstractItemView::SingleSelection);
 
   connect(ui->refreshButton, &QPushButton::clicked, this, [this]() {
-    fetchTorrents();
+    this->fetchTorrents();
+  });
+
+  connect(ui->torrentTable, &QTableView::doubleClicked, this, [this](const QModelIndex index) {
+      this->download(model->item(index));
   });
 
   connect(timer, SIGNAL(timeout()), this, SLOT(timerTick()));
@@ -128,6 +132,7 @@ void Torrents::downloadOnce(RSSItem *item) {
 }
 
 void Torrents::download(RSSItem *item) {
+  qDebug() << "Downloading " + item->fileName;
   FileDownloader f(item->link);
 
   QEventLoop evt;


### PR DESCRIPTION
This PR proposes an organization change in the Anime panel window.

The design is now more compact, the `Synonyms` and `Genres and Tags` groups have been moved under the cover image, leaving more room for the description group.
The `Details` group shows the main studios and the air date.

Also, the window name contains the anime title.

This is how it looks (left: this PR changes, right: current one):
![img](https://i.imgur.com/v09RMhm.png)