### PR TITLE
Add external(/custom) media player defintion support

### DIFF
--- a/src/detection/window_enumerator.cpp
+++ b/src/detection/window_enumerator.cpp
@@ -6,6 +6,7 @@
 #include <QJsonDocument>
 #include <QCoreApplication>
 #include <QString>
+#include <QDebug>
 
 #include <regex>
 
@@ -16,18 +17,11 @@
 using namespace Robot;
 
 WindowEnumerator::WindowEnumerator() : Singleton() {
-  QFile interalMediaPlayerJson(":/res/mediaPlayers.json");
-  interalMediaPlayerJson.open(QFile::ReadOnly);
-  readMediaPlayersJson(interalMediaPlayerJson);
+  readMediaPlayersJson(":/res/mediaPlayers.json");
 
   QString externalPath = QCoreApplication::applicationDirPath();
   externalPath.append("/customMediaPlayers.json");
-  QFile externalMediaPlayerJson(externalPath);
-  
-  if (externalMediaPlayerJson.exists()) {
-    externalMediaPlayerJson.open(QFile::ReadOnly);
-    readMediaPlayersJson(externalMediaPlayerJson);
-  }
+  readMediaPlayersJson(externalPath);
 
   for (auto &&playerName : m_mediaPlayers.keys()) {
     auto playerData = m_mediaPlayers.value(playerName).toObject();
@@ -149,10 +143,22 @@ void WindowEnumerator::processTitle(const std::string &title) {
   }
 }
 
-void WindowEnumerator::readMediaPlayersJson(const QFile &mediaPlayersJson) {
+void WindowEnumerator::readMediaPlayersJson(const QString &mediaPlayersJsonPath) {
+  QFile mediaPlayerJson(mediaPlayersJsonPath);
+
+  if (!mediaPlayerJson.exists()) {
+    qDebug() << "File not found" << mediaPlayersJsonPath;
+    return;
+  }
+
+  mediaPlayerJson.open(QFile::ReadOnly);
+
   auto mediaPlayers = QJsonDocument().fromJson(mediaPlayersJson.readAll()).object();
 
   for(auto &&playerName : mediaPlayers.keys()) {
+    if (m_mediaPlayers.contains(playerName)) {
+      qInfo() << "Media Player already existed," << playerName;
+    }
     m_mediaPlayers[playerName] = mediaPlayers[playerName];
   }
 }

--- a/src/detection/window_enumerator.h
+++ b/src/detection/window_enumerator.h
@@ -7,6 +7,7 @@
 #include <QMap>
 #include <QString>
 #include <QTimer>
+#include <QFile>
 
 #include <Robot.h>
 #include <anitomy/anitomy.h>
@@ -27,6 +28,7 @@ class WindowEnumerator : public Singleton<WindowEnumerator> {
   bool isMediaPlayer(const Robot::Process &process);
   bool detectMedia(const Robot::Process &process);
   void processTitle(const std::string &title);
+  void readMediaPlayersJson(const QFile &mediaPlayersJson);
 
  private:
   QJsonObject m_mediaPlayers;

--- a/src/detection/window_enumerator.h
+++ b/src/detection/window_enumerator.h
@@ -7,7 +7,7 @@
 #include <QMap>
 #include <QString>
 #include <QTimer>
-#include <QFile>
+#include <QString>
 
 #include <Robot.h>
 #include <anitomy/anitomy.h>
@@ -28,7 +28,7 @@ class WindowEnumerator : public Singleton<WindowEnumerator> {
   bool isMediaPlayer(const Robot::Process &process);
   bool detectMedia(const Robot::Process &process);
   void processTitle(const std::string &title);
-  void readMediaPlayersJson(const QFile &mediaPlayersJson);
+  void readMediaPlayersJson(const QString &mediaPlayersJson);
 
  private:
   QJsonObject m_mediaPlayers;


### PR DESCRIPTION
Currently there is no example of the custom support, but it's the exact same format as [mediaPlayers.json](https://github.com/ShinjiruApp/Shinjiru/blob/master/res/mediaPlayers.json) but in a file called `customMediaPlayers.json` along side the .exe (In theory...)

The custom media player definitions overwrite the base ones, meaning that if you want to extend MPC-HC support, it means you need to re-define the entire json object.