### PR TITLE
Add GenericName to Shinjiru.desktop.in

### DIFF
--- a/Shinjiru.desktop.in
+++ b/Shinjiru.desktop.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Shinjiru
+GenericName=Anime tracker for Anilist
 Comment=Qt-based anime recognition and list managment tool for AniList
 Icon=Shinjiru
 Terminal=false


### PR DESCRIPTION
This helps filtering/search in some tools like `rofi`. Shinjiru it's not a very easy name to remember, so if I type `anilist` in rofi it should search in the GenericName too (but not in the Comment section).

![image](https://user-images.githubusercontent.com/7642878/45271424-6953e500-b496-11e8-9562-3a5b07da8d4d.png)
