### PR TITLE
Changed setAlternatingRowColors() to false in anime_table.cpp

### DIFF
--- a/res/style.qss
+++ b/res/style.qss
@@ -117,15 +117,9 @@ QTabBar::tab:selected {
   font-weight: 500;
 }
 
-QTableView {
-  alternate-background-color: #FAFAFA;
-}
-
 QComboBox {
   padding-left: 5px;
   padding-right: 5px;
-  color: black;
-  background-color: transparent;
   outline: 0;
   border: 1px solid grey;
 }

--- a/ui/main_window/views/anime_table.cpp
+++ b/ui/main_window/views/anime_table.cpp
@@ -29,7 +29,7 @@ AnimeTable::AnimeTable(QWidget *parent, QSet<int> list) : QTableView(parent) {
 
   setSortingEnabled(true);
   sortByColumn(ListRoles::Title, Qt::AscendingOrder);
-  setAlternatingRowColors(true);
+  setAlternatingRowColors(false);
 
   horizontalHeader()->setStretchLastSection(true);
 

--- a/ui/main_window/views/anime_table.cpp
+++ b/ui/main_window/views/anime_table.cpp
@@ -29,7 +29,7 @@ AnimeTable::AnimeTable(QWidget *parent, QSet<int> list) : QTableView(parent) {
 
   setSortingEnabled(true);
   sortByColumn(ListRoles::Title, Qt::AscendingOrder);
-  setAlternatingRowColors(false);
+  setAlternatingRowColors(true);
 
   horizontalHeader()->setStretchLastSection(true);
 


### PR DESCRIPTION
On Linux with dark themes the Anime Table was alternating between a dark and white background while keeping the white font making it impossible to read the text in those fields.
This changes disables the alternating pattern making it uniformly dark (or white on light themes).